### PR TITLE
Use fixed dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,12 @@ RUN apk update && \
   pip install --upgrade \
     pip && \
   pip install \
-    azure-common \
-    cryptography \
-    azure-servicemanagement-legacy \
-    azure-storage \
-    blobxfer && \
+    azure-common>=1.0.0 \
+    requests>=2.9.1 \
+    cryptography>=1.2.2 \
+    azure-servicemanagement-legacy>=0.20.1 \
+    azure-storage>=0.20.3 \
+    blobxfer==0.9.9.11 && \
   rm -rf /var/cache/apk/*
 
 ADD drone-azure-storage /bin/


### PR DESCRIPTION
Breaking changes in dependencies should not break this image.

The following dependencies of blobxfer `0.9.9.11` are used in the modified `Dockerfile`:

```
azure-common >= 1.0.0
requests >= 2.9.1
cryptography >= 1.2.2
azure-servicemanagement-legacy >= 0.20.1
azure-storage >= 0.20.3
```

This PR resolves #6.
