### PR TITLE
Upversion dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN apk update && \
     requests>=2.9.1 \
     cryptography>=1.2.2 \
     azure-servicemanagement-legacy>=0.20.1 \
-    azure-storage>=0.20.3 \
-    blobxfer==0.9.9.11 && \
+    azure-storage==0.33.0 \
+    blobxfer==0.12.0 && \
   rm -rf /var/cache/apk/*
 
 ADD drone-azure-storage /bin/


### PR DESCRIPTION
Use of the dependency 

```
    azure-storage>=0.20.3
```

is incompatible with

```
    blobxfer==0.9.9.11
```

Increase version of dependencies and lock to specific versions.
