### PR TITLE
Fix README.md JSON payload example for rel/0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ make deps build
         "finished_at": 1421029813,
         "message": "Update the Readme",
         "author": "johnsmith",
-        "author_email": "john.smith@gmail.com"
+        "author_email": "john.smith@gmail.com",
         "event": "push",
         "branch": "master",
         "commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",
@@ -84,7 +84,7 @@ docker run -i plugins/drone-azure-storage <<EOF
         "finished_at": 1421029813,
         "message": "Update the Readme",
         "author": "johnsmith",
-        "author_email": "john.smith@gmail.com"
+        "author_email": "john.smith@gmail.com",
         "event": "push",
         "branch": "master",
         "commit": "436b7a6e2abaddfd35740527353e78a227ddcb2c",


### PR DESCRIPTION
Example JSON payload is missing a comma after the email address.

Very minor point but a pain to find when testing.