### PR TITLE
remove version constraint and add target option

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -4,6 +4,7 @@ Use this plugin for publishing files and artifacts to Azure Storage. The plugin 
 * `storage_account` - Storage Account name
 * `container` - The target storage container
 * `source` - Location of folder to sync relative to the workspace root
+* `target` - Remote resource location
 
 ## Example
 
@@ -16,4 +17,5 @@ publish:
     storage_account: my-storage-account
     container: my-storage-container
     source: folder/to/upload
+    target: target/path
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,8 @@ RUN apk update && \
     python-dev \
     libffi-dev \
     openssl-dev && \
-  pip install --upgrade \
-    pip && \
-  pip install \
-    azure-common>=1.0.0 \
-    requests>=2.9.1 \
-    cryptography>=1.2.2 \
-    azure-servicemanagement-legacy>=0.20.1 \
-    azure-storage>=0.20.3 \
-    blobxfer==0.9.9.11 && \
+  pip install --upgrade pip && \
+  pip install blobxfer && \
   rm -rf /var/cache/apk/*
 
 ADD drone-azure-storage /bin/

--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/drone/drone-plugin-go/plugin"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/drone/drone-plugin-go/plugin"
 )
 
 var (
@@ -18,6 +19,7 @@ type AzureBlobxfer struct {
 	StorageAccountName string `json:"storage_account"`
 	Container          string `json:"container"`
 	Source             string `json:"source"`
+	Target             string `json:"target"`
 }
 
 func main() {
@@ -44,7 +46,10 @@ func main() {
 	trace(cmd)
 
 	// Append StorageAccountKey to the cmd after trace to avoid exposing the key
-	cmd.Args = append(cmd.Args, "--storageaccountkey", vargs.StorageAccountKey)
+	cmd.Args = append(cmd.Args, "--storageaccountkey", vargs.StorageAccountKey, "--upload")
+	if len(vargs.Target) > 0 {
+		cmd.Args = append(cmd.Args, "--remoteresource", vargs.Target)
+	}
 	cmd.Env = os.Environ()
 	cmd.Dir = workspace.Path
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
With current version of plugin, blobxfer
crashes with unknown BlobStorage traceback.
Removing version constraint and rebuilding
container helped.

Also PR adds target option, which allows specifying remote
path for blobs.